### PR TITLE
xbmclog

### DIFF
--- a/Kodi/script.service.alexa/addon.py
+++ b/Kodi/script.service.alexa/addon.py
@@ -1,0 +1,11 @@
+import xbmcaddon
+
+### Addon Details ###
+ADDON       = xbmcaddon.Addon()
+ADDON_ID    = ADDON.getAddonInfo("id")
+ADDON_NAME  = ADDON.getAddonInfo("name")
+ADDON_PATH  = ADDON.getAddonInfo("path")
+ADDON_VER   = ADDON.getAddonInfo("version")
+
+### SETTINGS ###
+CLI_MODE    = False # No CLI has been implemented (this is a setting imported from xbmcswift2)

--- a/Kodi/script.service.alexa/logger.py
+++ b/Kodi/script.service.alexa/logger.py
@@ -1,0 +1,78 @@
+# attribution: original source from xbmcswift2.logger
+import logging
+import xbmc
+from addon import ADDON_ID, CLI_MODE
+
+
+# TODO: CLI mode currently just logs to file '%(ADDON_ID)s.log'
+#       Actual CLI could be more useful for debugging/testing purposes.
+# TODO: Allow a global flag to set logging level when dealing with XBMC
+# TODO: Add -q and -v flags to CLI to quiet or enable more verbose logging
+
+
+class XBMCFilter(object):
+    '''A logging filter that streams to file or to the xbmc log if
+    running inside XBMC.
+    '''
+    python_to_xbmc = {
+        'DEBUG': 'LOGDEBUG',
+        'INFO': 'LOGNOTICE',
+        'WARNING': 'LOGWARNING',
+        'ERROR': 'LOGERROR',
+        'CRITICAL': 'LOGSEVERE',
+    }
+
+    xbmc_levels = {
+        'LOGDEBUG': 0,
+        'LOGINFO': 1,
+        'LOGNOTICE': 2,
+        'LOGWARNING': 3,
+        'LOGERROR': 4,
+        'LOGSEVERE': 5,
+        'LOGFATAL': 6,
+        'LOGNONE': 7,
+    }
+
+    def __init__(self, prefix):
+        self.prefix = prefix
+
+    def filter(self, record):
+        # When running in XBMC, any logged statements will be double printed
+        # since we are calling xbmc.log() explicitly. Therefore we return False
+        # so every log message is filtered out and not printed again.
+        if CLI_MODE:
+            return True
+        else:
+            # Must not be imported until here because of import order issues
+            # when running in CLI
+            xbmc_level = XBMCFilter.xbmc_levels.get(
+                XBMCFilter.python_to_xbmc.get(record.levelname))
+            xbmc.log('%s %s' % (self.prefix, record.getMessage()), xbmc_level)
+            return False
+
+
+if CLI_MODE:
+    GLOBAL_LOG_LEVEL = logging.INFO
+else:
+    GLOBAL_LOG_LEVEL = logging.DEBUG
+
+
+def setup_log(name):
+    '''Returns a logging instance for the provided name. The returned
+    object is an instance of logging.Logger. Logged messages will be
+    printed to file when running in the CLI, or forwarded to XBMC's
+    log when running in XBMC mode.
+    '''
+    _log = logging.getLogger(name)
+    _log.setLevel(GLOBAL_LOG_LEVEL)
+    if CLI_MODE:
+        handler = logging.FileHandler('%s.log' % name)
+    else:
+        handler = logging.StreamHandler()
+        
+    handler.setFormatter(logging.Formatter('[%(name)s] %(message)s'))
+    _log.addHandler(handler)
+    _log.addFilter(XBMCFilter('[%s]' % name))
+    return _log
+
+log = setup_log(ADDON_ID)

--- a/Kodi/script.service.alexa/service.py
+++ b/Kodi/script.service.alexa/service.py
@@ -4,26 +4,24 @@ import os
 import time
 import random
 import xbmc
-import xbmcaddon
 import json
 import stream
 import traceback
 import urllib
+from addon import ADDON, ADDON_NAME, ADDON_VER
+from logger import log
 
-__addon__ = xbmcaddon.Addon()
-__cwd__=xbmc.translatePath(__addon__.getAddonInfo('path')).decode("utf-8")
-BASE_RESOURCE_PATH = os.path.join(__cwd__,'lib')
-sys.path.append(BASE_RESOURCE_PATH)
-
-
+sys.path.append(os.path.join(os.path.dirname(__file__), 'lib'))
 from socketIO_client import SocketIO,LoggingNamespace
 
-addon = xbmcaddon.Addon('script.service.alexa')
-user_id = addon.getSetting('authcode')
+user_id = ADDON.getSetting('authcode')
 socket_url = 'http://ec2-54-191-98-39.us-west-2.compute.amazonaws.com'
 socket_port= 3000
 socketIO = None
 
+log.info('Script [%s] version [%s]' % (ADDON_NAME, ADDON_VER))
+log.info('remote:  \t%s:%s' % (socket_url, socket_port))
+log.info('authcode:\t%s' % user_id)
 
 supported_movie_addons=['addon.video.pulsar','addon.video.quasar']
 supported_series_addons=['addon.video.pulsar','addon.video.quasar']
@@ -31,11 +29,17 @@ supported_series_addons=['addon.video.pulsar','addon.video.quasar']
 movie_addons = ['quasar']
 series_addons = ['quasar']
 
+while len(user_id) < 15:
+    xbmc.executebuiltin('Notification(Alexa Service,Please enter a valid key into the alexa service)')
+    for i in range(60):
+        time.sleep(1)
+    user_id = ADDON.getSetting('authcode')
+
 
 def setup_addons():
     video_addons = sendJSONRPC('Addons.GetAddons',{"type":"xbmc.addon.video","content":"video","enabled":"true","properties":["path","name"]})
     
-    print video_addons
+    log.info(video_addons)
     return
     for video in video_addons:
         #print video
@@ -45,19 +49,12 @@ def setup_addons():
             series_addons.add(video.name)
 
 
-while len(user_id) < 15:
-    xbmc.executebuiltin('Notification(Alexa Service,Please enter a valid key into the alexa service)')
-    for i in range(60):
-        time.sleep(1)
-    queue_id = addon.getSetting('authcode')
-
-
 def sendJSONRPC(method,params=None):
     out = {"id":1,"jsonrpc":"2.0","method":method}
     if params:
         out["params"] = params
     sendstring = json.dumps(out)
-    print sendstring
+    log.info(sendstring)
     return json.loads(xbmc.executeJSONRPC(sendstring))
 
 
@@ -65,7 +62,7 @@ def play_generic_addon(message_attributes):
     addons = sendJSONRPC('Addons.GetAddons',{"enabled":true,"properties":["path","name"]})
     for video in video_addons:
         if message_attributes['addon'] in video.name:
-            print "FOUND IT"
+            log.info('\taddon found')
     return
 
 def listen_pandora(message_attributes):#(stationname):
@@ -126,40 +123,25 @@ def menu_select():
     sendJSONRPC('Input.Select')
 
 def watch_netflix(title,netflixid):
-
-    print "received netflixID " + netflixid
+    log.info('watch_netflix(%s)' % netflixid)
 
     ## THIS METHOD OPENS IN CHROME, NON FULL SCREEN
-    
+
     #url = 'http://netflix.com/watch/'+netflixid
     #print url
     #webbrowser.get(chrome_path).open(url)
-    
-    #stringparam = ''
-    
+
     ## THIS METHOD USES KODI CHROME LAUNCHER TO LAUNCH FIREFOX IN KIOSK MODE
-    
-    #if  xbmc.getCondVisibility("system.platform.android"):
-    stringparam = 'http://netflix.com/watch/' + netflixid
-    #else:
-        #stringparam = '?kiosk=yes&mode=showSite&stopPlayback=yes&url=http://netflix.com/watch/'+netflixid
-
-    #headers = {'content-type':'application/json'};
-    #payload = {'jsonrpc':'2.0','method':'Addons.ExecuteAddon','params':{'addonid':'plugin.program.chrome.launcher','params':[stringparam]}}
-    #print xbmc.JSONRPC.Ping() 
-    #xbmc.GUI.ActivateWindow(window="home")  
-    #print stringparam
-    #os.system("pkill chrome")
-    #time.sleep(3)
+    stringparam = 'http://netflix.com/watch/' + netflixid # rely on launch_chrome to format kiosk tokens as needed
     launch_chrome(stringparam)
-    #sendJSONRPC('Addons.ExecuteAddon',{'addonid':'plugin.program.chrome.launcher','params':[stringparam]})
-    #xbmc.Addons.ExecuteAddon(addonid='plugin.program.chrome.launcher',params=[stringparam])
-
 
     return send_response_message("Playing, " + title + ", on Netflix",title + " played on Netflix")
 
 
 def watch_movie_addon(addon,title,imdbid):
+
+    log.info('watch_movie_addon(%s, %s, %s)' % (addon, title, imdbid))
+
     sendJSONRPC('Player.Open',{'item':{"file":"plugin://plugin.video."+addon+"/movie/"+imdbid+"/play"}})
 
     return send_response_message("Playing the Movie, " + title + ", on " + addon,title + " played on " + addon)
@@ -168,7 +150,7 @@ def watch_movie_addon(addon,title,imdbid):
 
 def watch_series_addon(addon,title,tvdbid,seasonNum,episodeNum,episode_title):
 
-
+    log.info('watch_series_addon(%s, %s, %s, %s, %s, %s)' % (addon,title,tvdbid,seasonNum,episodeNum,episode_title))
 
     if seasonNum and episodeNum:
         sendJSONRPC('Player.Open',{'item':{"file":"plugin://plugin.video."+addon+"/show/"+tvdbid+"/season/"+seasonNum+"/episode/"+episodeNum+"/play"}})
@@ -187,7 +169,7 @@ def watch_series_addon(addon,title,tvdbid,seasonNum,episodeNum,episode_title):
     
  
 def get_currently_playing(message_attributes):
-    print "getting currently playing"
+    log.info("get_currently_playing(..)")
     response = sendJSONRPC("Player.GetItem",{ "properties": ["title"], "playerid": GetPlayerID() })
     title = response.get("result",[]).get("item").get("title")
     return tell_response_message("Currently Playing " + title, "Currently Playing " + title)
@@ -202,10 +184,12 @@ def GetPlayerID():
 
 
 def play_pause(message_attributes):
+    log.info("play_pause(..)")
     sendJSONRPC("Player.PlayPause", {"playerid":GetPlayerID()})
     send_response_message("Ok","Kodi Pause/Resumed")
     
 def stop(message_attributes):
+    log.info("stop(..)")
     sendJSONRPC("Player.Stop", {"playerid":GetPlayerID()})
     send_response_message("Ok","Kodi Stopped")
 
@@ -214,6 +198,8 @@ def play_music(message_attributes):
     
     
 def play_movie(message_attributes):#(title,imdbid,netflixid):
+
+    log.info("play_movie(..)")
 
     try:
         title = message_attributes['title']['StringValue']
@@ -229,12 +215,12 @@ def play_movie(message_attributes):#(title,imdbid,netflixid):
         for movie in movies:
             print movie['imdbnumber']
             if movie['imdbnumber'] == imdbid:
-                print "playng " + movie['label'] + " " + str(movie['movieid'])
+                log.info("\tplaying " + movie['label'] + " " + str(movie['movieid']))
                 tell_response_message("Playing the Movie, " + title + ", locally on Kodi",title + " played locally")
                 play_local_movie(movie['movieid'])
                 return 
     except:
-        print "local movie playback failed"
+        log.info("\tlocal movie playback failed")
         
     if netflixid != '-1':
         try:
@@ -265,7 +251,8 @@ def play_local_show(episode_id):
 
 def play_series(message_attributes):
 
-    #print message_attributes
+    log.info("play_series(..)")
+
     title = message_attributes['title']['StringValue']
     imdbid = message_attributes['imdbid']['StringValue']
 
@@ -286,7 +273,7 @@ def play_series(message_attributes):
     library = sendJSONRPC('VideoLibrary.GetTVShows',{'properties':["imdbnumber"]})
     #library = xbmc.VideoLibrary.GetTVShows(properties=["imdbnumber"])
     
-    print library
+    #print library
     #return
     try:
         shows = library['result']['tvshows']
@@ -331,13 +318,13 @@ def play_series(message_attributes):
                 for episode in episodes: 
                     #print " checking " + season_number + " vs " + episode['season'] + " and " + episode_number + " vs " +episode['episode']
                     if episode['season'] == int(season_number) and episode['episode'] == int(episode_number):
-                        print "playing " + show['label'] + " " + str(episode['episodeid'])
+                        log.info("\tplaying " + show['label'] + " " + str(episode['episodeid']))
                         play_local_show(episode['episodeid'])
                         return tell_response_message("Playing, " + title + "," + episode_title + ", locally on Kodi",title + " played locally")
                     
                          
     except:
-        print "local show playback failed"
+        log.info("\tlocal show playback failed")
     
     if netflixid != '-1':
         try:
@@ -351,8 +338,8 @@ def play_series(message_attributes):
                 return watch_series_addon(addon, title,show_tvdbid,season_number,episode_number,episode_title)
             except:
                 return tell_response_message("There was a problem playing with " + addon, "There was a problem playing with " + addon)
-        
-    
+
+    log.info("\tepisode source not found. Exiting")
     return tell_response_message("Couldn't find a source", "Couldn't find a source")
 
 
@@ -367,19 +354,19 @@ def play_random_movie():
 
 def play_internet_stream(message_attributes):
 
-    
-    print message_attributes
+    log.info("play_internet_stream(..)")
+    #print message_attributes
     send_response_message("good","good")
     # Try to play on Kodi
     streamNum = 0
     while 'url' + str(streamNum) in message_attributes:
-        print "Stream number + " + str(streamNum)
+        log.info("\tStream number + " + str(streamNum))
         urlin = message_attributes['url' + str(streamNum)]['StringValue']
-        print "calling getURL"
+        log.info("\tcalling getURL")
         url = stream.GetStreams(urlin)
         streamNum = streamNum +1
-        
-        print "URL is " + str(url)
+
+        log.info("\tURL is " + str(url))
         if url:
             return sendJSONRPC('Player.Open',{'item':{"file":url}})
             
@@ -399,8 +386,7 @@ def play_internet_stream(message_attributes):
 
 def launch_chrome(url):
 
-    
-    print "URL IS: " + url
+    log.info("launch_chrome(%s)" % url)
     
     if xbmc.getCondVisibility("system.platform.android"):
         xbmc.executebuiltin("XBMC.StartAndroidActivity(com.android.chrome,android.intent.action.VIEW,,"+url+")")
@@ -411,7 +397,9 @@ def launch_chrome(url):
     
     
 def recent_episodes(message_attributes):
-    print "made it to recent episodes"
+
+    log.info("recent_episodes()")
+
     response = sendJSONRPC("VideoLibrary.GetRecentlyAddedEpisodes", { "properties": [ "title", "showtitle" ],"limits":{"end":5}})
     print response
     try:
@@ -421,11 +409,14 @@ def recent_episodes(message_attributes):
     speech = "Your newest episodes are. "
     for episode in episodes:
         speech = speech + episode['showtitle'] +', ' + episode['title'] + '.  '
-        
-    print speech
+
+    log.info(speech)
     return  tell_response_message(speech,speech)
     
 def recent_movies(message_attributes):
+
+    log.info("recent_movies(..)")
+
     sendJSONRPC("VideoLibrary.GetRecentlyAddedMovies", { "properties": [ "title"],"limits":{"end":5 }})
     try:
         movies = response['result']['movies']
@@ -434,6 +425,8 @@ def recent_movies(message_attributes):
     speech = "Your newest movies are: "
     for movie in movies:
         speech = speech + movie['title'] + '.  '
+
+    log.info(speech)
     return tell_response_message(speech,speech)
 
 def navigate(message_attributes):
@@ -523,24 +516,28 @@ message_router = {
 xbmc.executebuiltin('Notification(Alexa Service,Started,5000,/icon.png)')
 
 def handle_disconnect(*args):
+    log.info('socketio:handle_disconnect()')
     xbmc.executebuiltin('Notification(Alexa Service,Disconnect, reconnecting!, 5000,/icon.png)')
 
 
 def execute_command(*args):
     arg = args[0]
-    print('execute_command', arg)
-    
+
+    log.info('socketio:execute_command()')
+    log.info(arg)
+
     #json_args = json.loads(args)
     #print json_args
     try:
         message_router[arg['message']['body']](arg['message']['message_attributes'])
     except Exception as e:
-        print e
+        log.info(e)
         traceback.print_exc()
         send_response_message("Error with command " + message[0].body + ". Make sure your schema is up to date","ERROR:" + str(e) + " "+ str(traceback.format_exc()))
         
 
 def reconnect():
+    log.info('socektio:reconnect()')
     global socketIO
     socketIO.emit('add client',user_id)
 
@@ -549,15 +546,19 @@ def reconnect():
     
 #setup_addons()   
 socketIO = SocketIO(socket_url,socket_port,LoggingNamespace)
+log.info('websocket object created')
+
 socketIO.emit('add client',user_id)
+log.info('\tclient added (%s)' % user_id)
+
 socketIO.on('disconnect',handle_disconnect)
 socketIO.on('server message',execute_command)
 socketIO.on('reconnect',reconnect)
+log.info('\tmessage hooks added')
 #socketIO.wait()
     
-    
+log.info('websocket listening')
 while(1):
     socketIO.wait()
-    print "listening again"
 
     #time.sleep(1)


### PR DESCRIPTION
Migrate debug **print** to use python's [logging](https://docs.python.org/2/library/logging.html) system (via **xbmc.log** or **stdout**). 
- logger.py (stream/filehandler for logging with addon id used as filter)
- addon.py (easy-to-import ADDON object)

Attribution of initial source to **xbmcswift2**

Usage: 
`from logger import log`
`...`
`log.debug('this is logged if log.getLeve() == logging.DEBUG')`
`log.info('this message logged as logging.INFO')`
`log.warning('this is a warning')`
